### PR TITLE
Parameterize TOC marker pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ md.use(require("markdown-it-table-of-contents", options));
 
 These options are available:
 
-Name              | Description                               | Default
-------------------|-------------------------------------------|------------------------------------
-"includeLevel"    | Headings levels to use (2 for h2:s etc)   | [1, 2]
-"containerClass"  | The class for the container DIV           | "table-of-contents"
-"slugify"         | A custom slugification function           | [string.js' `slugify`][slugify]
+Name              | Description                                         | Default
+------------------|-----------------------------------------------------|------------------------------------
+"includeLevel"    | Headings levels to use (2 for h2:s etc)             | [1, 2]
+"containerClass"  | The class for the container DIV                     | "table-of-contents"
+"slugify"         | A custom slugification function                     | [string.js' `slugify`][slugify]
+"markerPattern"   | Regex pattern of the marker to be replaced with TOC | `/^\[\[toc\]\]/im`
 
 [slugify]: http://stringjs.com/#methods/slugify

--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ var defaults = {
   containerClass: "table-of-contents",
   slugify: function(str) {
     return string(str).slugify().toString();
-  }
+  },
+  markerPattern: /^\[\[toc\]\]/im
 };
 
 module.exports = function(md, options) {
   var options = assign({}, defaults, options);
-  var tocRegexp = /^\[\[toc\]\]/im;
+  var tocRegexp = options.markerPattern;
   var gstate;
 
   function toc(state, silent) {


### PR DESCRIPTION
This change makes TOC marker adjustable with the `markerPattern` option.

Default value remains `/^\[\[toc\]\]/im`, so the change is backward compatible.
