### PR TITLE
add option to filter headings through function

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,15 @@ Name              | Description                                         | Defaul
 "slugify"         | A custom slugification function                     | [string.js' `slugify`][slugify]
 "markerPattern"   | Regex pattern of the marker to be replaced with TOC | `/^\[\[toc\]\]/im`
 "listType"        | Type of list (`ul` for unordered, `ol` for ordered) | `ul`
+"format"          | A function for formatting headings (see below)      | `undefined`
+
+
+`format` is an optional function for changing how the headings are displayed in the TOC.
+```js
+function format(headingAsString) {
+  // manipulate the headings as you like here.
+  return manipulatedHeadingString;
+}
+```
 
 [slugify]: http://stringjs.com/#methods/slugify

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var defaults = {
     return string(str).slugify().toString();
   },
   markerPattern: /^\[\[toc\]\]/im,
-  listType: "ul"
+  listType: "ul",
+  format: undefined
 };
 
 module.exports = function(md, options) {
@@ -107,7 +108,9 @@ module.exports = function(md, options) {
           headings.push(buffer);
         }
       }
-      buffer = "<li><a href=\"#" + options.slugify(heading.content) + "\">" + heading.content + "</a>";
+      buffer = "<li><a href=\"#" + options.slugify(heading.content) + "\">";
+      buffer += typeof options.format === "function" ? options.format(heading.content) : heading.content;
+      buffer += "</a>";
       i++;
     }
     buffer += "</li>";


### PR DESCRIPTION
Passes headings through a function from options.

Examples:
Your markdown:
```markdown
[[toc]]
## Magic:

## Dinosaurs:
```

1. All your headings are followed by a colon, but you want the table of contents to not have them:

Your javascript:
```js
const headingFilter = heading => {
  return heading.substr(0, heading.length - 1);
};

md.use(require('markdown-it-table-of-contents'), {filter: headingFilter});

console.log(md.render(markdown));

// toc part renders without the colons!
// <ul>
// <li><a href='#magic'>Magic</li>
// <li><a href='#dinosaurs'>Dinosaurs</li>
// </ul>
```

2. You think it's a great idea for your table of contents items to be in ALL CAPS:

Your javascript:
```js
const headingFilter = heading => {
  return heading.toUpperCase();
};

md.use(require('markdown-it-table-of-contents'), {filter: headingFilter});

console.log(md.render(markdown));

// TOC part renders in ALL CAPS!
// <ul>
// <li><a href='#magic'>MAGIC:</li>
// <li><a href='#dinosaurs'>DINOSAURS:</li>
// </ul>
```