### PR TITLE
added option to skip rendering certain headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ md.use(require("markdown-it-table-of-contents"), options);
 
 These options are available:
 
-Name              | Description                                         | Default
-------------------|-----------------------------------------------------|------------------------------------
-"includeLevel"    | Headings levels to use (2 for h2:s etc)             | [1, 2]
-"containerClass"  | The class for the container DIV                     | "table-of-contents"
-"slugify"         | A custom slugification function                     | [string.js' `slugify`][slugify]
-"markerPattern"   | Regex pattern of the marker to be replaced with TOC | `/^\[\[toc\]\]/im`
-"listType"        | Type of list (`ul` for unordered, `ol` for ordered) | `ul`
-"format"          | A function for formatting headings (see below)      | `undefined`
+Name              | Description                                             | Default
+------------------|---------------------------------------------------------|------------------------------------
+"includeLevel"    | Headings levels to use (2 for h2:s etc)                 | [1, 2]
+"containerClass"  | The class for the container DIV                         | "table-of-contents"
+"slugify"         | A custom slugification function                         | [string.js' `slugify`][slugify]
+"markerPattern"   | Regex pattern of the marker to be replaced with TOC     | `/^\[\[toc\]\]/im`
+"listType"        | Type of list (`ul` for unordered, `ol` for ordered)     | `ul`
+"format"          | A function for formatting headings (see below)          | `undefined`
+"skipHeadings"    | Array of strings to not include in TOC (case sensitive) | `[]`
 
 
 `format` is an optional function for changing how the headings are displayed in the TOC.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var defaults = {
   },
   markerPattern: /^\[\[toc\]\]/im,
   listType: "ul",
-  format: undefined
+  format: undefined,
+  skipHeadings: []
 };
 
 module.exports = function(md, options) {
@@ -79,6 +80,7 @@ module.exports = function(md, options) {
         currentLevel,
         subHeadings,
         size = tokens.length,
+        didRender = false,
         i = pos;
     while(i < size) {
       var token = tokens[i];
@@ -96,21 +98,26 @@ module.exports = function(md, options) {
           i = subHeadings[0];
           continue;
         }
-        if (level < currentLevel) {
+        if (level < currentLevel && didRender) {
           // Finishing the sub headings
           buffer += "</li>";
           headings.push(buffer);
+          didRender = false;
           return [i, "<" + options.listType + ">" + headings.join("") + "</" + options.listType + ">"];
         }
-        if (level == currentLevel) {
+        if (level == currentLevel && didRender) {
           // Finishing the sub headings
           buffer += "</li>";
           headings.push(buffer);
+          didRender = false;
         }
       }
-      buffer = "<li><a href=\"#" + options.slugify(heading.content) + "\">";
-      buffer += typeof options.format === "function" ? options.format(heading.content) : heading.content;
-      buffer += "</a>";
+      if (options.skipHeadings.indexOf(heading.content) < 0) {
+        buffer = "<li><a href=\"#" + options.slugify(heading.content) + "\">";
+        buffer += typeof options.format === "function" ? options.format(heading.content) : heading.content;
+        buffer += "</a>";
+        didRender = true;
+      }
       i++;
     }
     buffer += "</li>";

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -75,6 +75,15 @@ describe("Testing Markdown rendering", function() {
     done();
   });
 
+  it("Parses correctly with skipHeadings set", function(done) {
+    var tocItemToNotRender = '<li><a href="#sub-heading-1">Sub heading 1</a></li>';
+    md.use(markdownItTOC, {
+      "skipHeadings": ['Sub heading 1']
+    });
+    assert.equal(md.render(simpleMarkdown), simpleDefaultHTML.replace(tocItemToNotRender, ''));
+    done();
+  });
+
   it("Slugs matches markdown-it-anchor", function(done) {
     md.use(markdownItAnchor);
     md.use(markdownItTOC);


### PR DESCRIPTION
Not sure if this is something you would want, but I'll PR because I think it's a nice feature! If you'd prefer an `undefined` default, I can change it. I set it to an empty array for minimal code repetition and the performance difference would only be noticable if a page has 100s of headings to put in the TOC.

**Example:**
You have markdown
```markdown
# Table of contents
[[toc]]

# Magic

# Dinosaurs
```

Which has TOC section:
# Table of Contents
* Table of Contents
* Magic
* Dinosaurs

---

But you think putting "Table of Contents" _in_ the Table of Contents is an insult to the reader's intelligence, so you don't want it to be there.

```js
md.use(markdownItTOC, {
skipHeadings: ['Table of Contents']
});
```

Now your TOC renders as:
# Table of Contents
* Magic
* Dinosaurs