### PR TITLE
Fix broken edge case with soft breaks in the same token as [[toc]]. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,6 @@ module.exports = function(md, options) {
     var token;
     var match;
 
-    while (state.src.indexOf("\n") >= 0 && state.src.indexOf("\n") < state.src.indexOf("[[toc]]")) {
-      if (state.tokens.slice(-1)[0].type === "softbreak") {
-        state.src = state.src.split("\n").slice(1).join("\n");
-        state.pos = 0;
-      }
-    }
-
     // Reject if the token does not start with [
     if (state.src.charCodeAt(state.pos) !== 0x5B /* [ */ ) {
       return false;

--- a/test/fixtures/simple-1-level.html
+++ b/test/fixtures/simple-1-level.html
@@ -1,5 +1,6 @@
 <h1>An article</h1>
-<p><div class="table-of-contents"><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></div></p>
+<p>some text with soft break before toc<br>
+<div class="table-of-contents"><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></div></p>
 <h2>Sub heading 1</h2>
 <p>Some nice text</p>
 <h2>Sub heading 2</h2>

--- a/test/fixtures/simple-default.html
+++ b/test/fixtures/simple-default.html
@@ -1,5 +1,6 @@
 <h1>An article</h1>
-<p><div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
+<p>some text with soft break before toc<br>
+<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
 <h2>Sub heading 1</h2>
 <p>Some nice text</p>
 <h2>Sub heading 2</h2>

--- a/test/fixtures/simple-with-anchors.html
+++ b/test/fixtures/simple-with-anchors.html
@@ -1,5 +1,6 @@
 <h1 id="an-article">An article</h1>
-<p><div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
+<p>some text with soft break before toc<br>
+<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
 <h2 id="sub-heading-1">Sub heading 1</h2>
 <p>Some nice text</p>
 <h2 id="sub-heading-2">Sub heading 2</h2>

--- a/test/fixtures/simple.md
+++ b/test/fixtures/simple.md
@@ -1,5 +1,5 @@
 # An article
-
+some text with soft break before toc  
 [[toc]]
 
 ## Sub heading 1


### PR DESCRIPTION
Fixes https://github.com/Oktavilla/markdown-it-table-of-contents/issues/14

Removes weird legacy code that prevents parser to continue when encountering a soft break before [[toc]]