### PR TITLE
Fixed code to adjust ul element: style attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ var defaults = {
   listType: "ul",
   format: undefined
 };
+const bulletedListType = defaults.listType; //SA
+const noBulletStyle = " style=\"list-style-type: none;\""; //SA
 
 module.exports = function(md, options) {
   var options = assign({}, defaults, options);
@@ -93,7 +95,10 @@ module.exports = function(md, options) {
           // Finishing the sub headings
           buffer += "</li>";
           headings.push(buffer);
-          return [i, "<" + options.listType + ">" + headings.join("") + "</" + options.listType + ">"];
+          let effectiveStyle = "";
+          if (options.listType === bulletedListType) // SA
+            effectiveStyle = noBulletStyle;
+          return [i, "<" + options.listType + effectiveStyle + ">" + headings.join("") + "</" + options.listType + ">"];
         }
         if (level == currentLevel) {
           // Finishing the sub headings
@@ -108,7 +113,10 @@ module.exports = function(md, options) {
     }
     buffer += "</li>";
     headings.push(buffer);
-    return [i, "<" + options.listType + ">" + headings.join("") + "</" + options.listType + ">"];
+    let effectiveStyle = ""; // SA
+    if (options.listType === bulletedListType) // SA
+      effectiveStyle = noBulletStyle;
+    return [i, "<" + options.listType + effectiveStyle + ">" + headings.join("") + "</" + options.listType + ">"];
   }
 
   // Catch all the tokens for iteration later


### PR DESCRIPTION
Background:

If ul element is chosen, bullets will appear on all rendered levels of TOC, which is hardly acceptable. The CSS solution would be changing the style of the element<div class="toc">:
toc ul { list-style-type: none; }

In many situations, CSS files are not accessible or cannot be modified. For example, please see this article and discussion with the maintainer of the site:
https://www.codeproject.com/Tips/1194157/A-suggestion-for-CodeProject-TOC-Style-Fix

Solution:
Adding "style" element to ul element (and not to any other elements) generated by markdown-it-table-of-contents, to produce <ul style="list-style-type: none;"> (commented "//SA")

See also:
https://marketplace.visualstudio.com/items?itemName=sakryukov.convert-markdown-to-html
https://github.com/SAKryukov/vscode-markdown-to-html.git

Thank you for your consideration.
—SA