### PR TITLE
Adding support to render full TOC is header orders are not as in decreasing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ md.use(require("markdown-it-table-of-contents"), options);
 
 These options are available:
 
-Name              | Description                                         | Default
-------------------|-----------------------------------------------------|------------------------------------
-"includeLevel"    | Headings levels to use (2 for h2:s etc)             | [1, 2]
-"containerClass"  | The class for the container DIV                     | "table-of-contents"
-"slugify"         | A custom slugification function                     | [string.js' `slugify`][slugify]
-"markerPattern"   | Regex pattern of the marker to be replaced with TOC | `/^\[\[toc\]\]/im`
-"listType"        | Type of list (`ul` for unordered, `ol` for ordered) | `ul`
-"format"          | A function for formatting headings (see below)      | `undefined`
+Name              | Description                                                                         | Default
+------------------|-------------------------------------------------------------------------------------|------------------------------------
+"includeLevel"    | Headings levels to use (2 for h2:s etc)                                             | [1, 2]
+"containerClass"  | The class for the container DIV                                                     | "table-of-contents"
+"slugify"         | A custom slugification function                                                     | [string.js' `slugify`][slugify]
+"markerPattern"   | Regex pattern of the marker to be replaced with TOC                                 | `/^\[\[toc\]\]/im`
+"listType"        | Type of list (`ul` for unordered, `ol` for ordered)                                 | `ul`
+"format"          | A function for formatting headings (see below)                                      | `undefined`
+"forceFullToc"    | If true, renders all the headers in TOC, even if the headers are in incorrect order | false
 
 
 `format` is an optional function for changing how the headings are displayed in the TOC.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var defaults = {
   },
   markerPattern: /^\[\[toc\]\]/im,
   listType: "ul",
-  format: undefined
+  format: undefined,
+  forceFullToc: false,
 };
 
 module.exports = function(md, options) {
@@ -63,7 +64,36 @@ module.exports = function(md, options) {
   };
 
   md.renderer.rules.toc_body = function(tokens, index) {
-    return renderChildsTokens(0, gstate.tokens)[1];
+    if (options.forceFullToc) {
+      /*
+      
+      Renders full TOC even if the hierarchy of headers contains
+      a header greater than the first appearing header
+      
+      ## heading 2
+      ### heading 3
+      # heading 1
+      
+      Result TOC:
+      - heading 2
+         - heading 3
+      - heading 1 
+
+      */
+      var tocBody = "";
+      var pos = 0;
+      var tokenLength = gstate && gstate.tokens && gstate.tokens.length;
+
+      while (pos < tokenLength) {
+        var tocHierarchy = renderChildsTokens(pos, gstate.tokens);
+        pos = tocHierarchy[0];
+        tocBody += tocHierarchy[1];
+      }
+
+      return tocBody;
+    } else {
+      return renderChildsTokens(0, gstate.tokens)[1];
+    }
   };
 
   function renderChildsTokens(pos, tokens) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "name": "markdown-it-table-of-contents",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/full-toc-sample-result.html
+++ b/test/fixtures/full-toc-sample-result.html
@@ -1,0 +1,6 @@
+<p>Some text with soft break before toc<br>
+<div class="table-of-contents"><ul><li><a href="#heading-2">Heading 2</a></li></ul><ul><li><a href="#heading-1">Heading 1</a></li></ul></div></p>
+<h2 id="heading-2">Heading 2</h2>
+<p>Some nice text</p>
+<h1 id="heading-1">Heading 1</h1>
+<p>Some text</p>

--- a/test/fixtures/full-toc-sample.md
+++ b/test/fixtures/full-toc-sample.md
@@ -1,0 +1,8 @@
+Some text with soft break before toc  
+[[toc]]
+
+## Heading 2
+Some nice text
+
+# Heading 1
+Some text

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -18,6 +18,8 @@ var simple1LevelHTML = fs.readFileSync("test/fixtures/simple-1-level.html", "utf
 var simpleWithAnchorsHTML = fs.readFileSync("test/fixtures/simple-with-anchors.html", "utf-8");
 var emptyMarkdown = defaultMarker;
 var emptyMarkdownHtml = fs.readFileSync("test/fixtures/empty.html", "utf-8");
+var fullTocSampleMarkdown = fs.readFileSync("test/fixtures/full-toc-sample.md", "utf-8");
+var fullTocSampleHtml = fs.readFileSync("test/fixtures/full-toc-sample-result.html", "utf-8");
 
 
 describe("Testing Markdown rendering", function() {
@@ -89,5 +91,11 @@ describe("Testing Markdown rendering", function() {
     md.use(markdownItTOC);
     assert.equal(md.render(emptyMarkdown), emptyMarkdownHtml);
     done();
-  })
+  });
+
+  it("Generates full TOC, even when there is a greater header than the first header", function (done) {
+    md.use(markdownItTOC, { forceFullToc: true });
+    assert.equal(md.render(fullTocSampleMarkdown), fullTocSampleHtml);
+    done();
+  });
 });


### PR DESCRIPTION
Adding support to render full TOC even if we have a header greater in weight than the first header encountered.

#### Example:
TOC:
- header 2
   - header 3
- header 1

Content: 
## heading 2

### heading 3

# heading 1

PS: I have added the test, but I am not able to validate them in my side, since all the tests are showing as failed in my setup. I would need some help in this area.