### PR TITLE
Fixing github issue #35

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (md, o) => {
     }
 
     // Detect TOC markdown
-    match = tocRegexp.exec(state.src);
+    match = tocRegexp.exec(state.src.substr(state.pos));
     match = !match ? [] : match.filter(function(m) { return m; });
     if (match.length < 1) {
       return false;


### PR DESCRIPTION
**Issue:**
- Multiple TOCs equal to the number of  "[" in the same state.src as that of the state which contains [[toc]].
- This is because we do the regex match on the whole src instead of the substring of the src from the position which we are currently processing.

**Solution:**
- Match the regex only from the position we are currently processing in the state.