### PR TITLE
Format markdown in TOC by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Name                   | Description                                            
 
 `format` is an optional function for changing how the headings are displayed in the TOC.
 
-By default, TOC headings will be formatted using markdown-it's internal MD formatting rules (i.e. it will be formatted the same rules / extensions other markdown in your document). You can override this behavior by specifying a custom `format` function. The function should accept two arguments:
+By default, TOC headings will be formatted using markdown-it's internal MD formatting rules (i.e. it will be formatted using the same rules / extensions as other markdown in your document). You can override this behavior by specifying a custom `format` function. The function should accept two arguments:
 
-1. `headingAsString` - The heading test, as a markdown string.
+1. `content` - The heading test, as a markdown string.
 2. `md` – markdown-it's internal markdown parser object. This should only be need for advanced use cases.
 
 ```js
-function format(headingAsString, md) {
+function format(content, md) {
   // manipulate the headings as you like here.
   return manipulatedHeadingString;
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Name                   | Description                                            
 "markerPattern"        | Regex pattern of the marker to be replaced with TOC                                 | `/^\[\[toc\]\]/im`
 "listType"             | Type of list (`ul` for unordered, `ol` for ordered)                                 | `ul`
 "format"               | A function for formatting headings (see below)                                      | `md.renderInline(content)`
-"forceFullToc"         | If true, renders all the headers in TOC, even if the headers are in incorrect order | false
 "containerHeaderHtml"  | Optional HTML string for container header                                           | `<div class="toc-container-header">Contents</div>`
 "containerFooterHtml"  | Optional HTML string for container footer                                           | `<div class="toc-container-footer">Footer</div>`
 "transformLink"        | A function for transforming the TOC links                                           | `undefined`

--- a/README.md
+++ b/README.md
@@ -73,8 +73,14 @@ Name                   | Description                                            
 "transformLink"        | A function for transforming the TOC links                                           | `undefined`
 
 `format` is an optional function for changing how the headings are displayed in the TOC.
+
+By default, TOC headings will be formatted using markdown-it's internal MD formatting rules (i.e. it will be formatted the same rules / extensions other markdown in your document). You can override this behavior by specifying a custom `format` function. The function should accept two arguments:
+
+1. `headingAsString` - The heading test, as a markdown string.
+2. `md` – markdown-it's internal markdown parser object. This should only be need for advanced use cases.
+
 ```js
-function format(headingAsString) {
+function format(headingAsString, md) {
   // manipulate the headings as you like here.
   return manipulatedHeadingString;
 }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Name                   | Description                                            
 "slugify"              | A custom slugification function                                                     | `encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'))`
 "markerPattern"        | Regex pattern of the marker to be replaced with TOC                                 | `/^\[\[toc\]\]/im`
 "listType"             | Type of list (`ul` for unordered, `ol` for ordered)                                 | `ul`
-"format"               | A function for formatting headings (see below)                                      | `undefined`
+"format"               | A function for formatting headings (see below)                                      | `md.renderInline(content)`
 "forceFullToc"         | If true, renders all the headers in TOC, even if the headers are in incorrect order | false
 "containerHeaderHtml"  | Optional HTML string for container header                                           | `<div class="toc-container-header">Contents</div>`
 "containerFooterHtml"  | Optional HTML string for container footer                                           | `<div class="toc-container-footer">Footer</div>`

--- a/index.js
+++ b/index.js
@@ -81,32 +81,7 @@ module.exports = function(md, o) {
 
   md.renderer.rules.toc_body = function(tokens, index) {
     if (options.forceFullToc) {
-      /*
-
-      Renders full TOC even if the hierarchy of headers contains
-      a header greater than the first appearing header
-
-      ## heading 2
-      ### heading 3
-      # heading 1
-
-      Result TOC:
-      - heading 2
-         - heading 3
-      - heading 1
-
-      */
-      var tocBody = '';
-      var pos = 0;
-      var tokenLength = gstate && gstate.tokens && gstate.tokens.length;
-
-      while (pos < tokenLength) {
-        var tocHierarchy = renderChildsTokens(pos, gstate.tokens);
-        pos = tocHierarchy[0];
-        tocBody += tocHierarchy[1];
-      }
-
-      return tocBody;
+      throw("forceFullToc was removed in version 0.5.0. For more information, see https://github.com/Oktavilla/markdown-it-table-of-contents/pull/41")
     } else {
       return renderChildsTokens(0, gstate.tokens)[1];
     }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ const defaults = {
   slugify,
   markerPattern: /^\[\[toc\]\]/im,
   listType: 'ul',
-  format: undefined,
+  format: (content, md) => {
+    return md.renderInline(content);
+  },
   forceFullToc: false,
   containerHeaderHtml: undefined,
   containerFooterHtml: undefined,
@@ -77,18 +79,18 @@ module.exports = (md, o) => {
   md.renderer.rules.toc_body = function(tokens, index) {
     if (options.forceFullToc) {
       /*
-      
+
       Renders full TOC even if the hierarchy of headers contains
       a header greater than the first appearing header
-      
+
       ## heading 2
       ### heading 3
       # heading 1
-      
+
       Result TOC:
       - heading 2
          - heading 3
-      - heading 1 
+      - heading 1
 
       */
       var tocBody = '';
@@ -143,7 +145,7 @@ module.exports = (md, o) => {
         }
       }
       buffer = `<li><a href="#${options.slugify(heading.content)}">`;
-      buffer += typeof options.format === 'function' ? options.format(heading.content) : heading.content;
+      buffer += options.format(heading.content, md);
       buffer += `</a>`;
       i++;
     }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 'use strict';
-const slugify = (s) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'));
-const defaults = {
+var slugify = function(s){
+  return encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'))
+};
+var defaults = {
   includeLevel: [ 1, 2 ],
   containerClass: 'table-of-contents',
-  slugify,
+  slugify: slugify,
   markerPattern: /^\[\[toc\]\]/im,
   listType: 'ul',
-  format: (content, md) => {
+  format: function(content, md) {
     return md.renderInline(content);
   },
   forceFullToc: false,
@@ -14,10 +16,10 @@ const defaults = {
   containerFooterHtml: undefined,
 };
 
-module.exports = (md, o) => {
-  const options = Object.assign({}, defaults, o);
-  const tocRegexp = options.markerPattern;
-  let gstate;
+module.exports = function(md, o) {
+  var options = Object.assign({}, defaults, o);
+  var tocRegexp = options.markerPattern;
+  var gstate;
 
   function toc(state, silent) {
     var token;
@@ -57,7 +59,7 @@ module.exports = (md, o) => {
   }
 
   md.renderer.rules.toc_open = function(tokens, index) {
-    var tocOpenHtml = `<div class="${options.containerClass}">`;
+    var tocOpenHtml = '<div class="'+ options.containerClass +'">';
 
     if (options.containerHeaderHtml) {
       tocOpenHtml += options.containerHeaderHtml;
@@ -73,7 +75,7 @@ module.exports = (md, o) => {
       tocFooterHtml = options.containerFooterHtml;
     }
 
-    return tocFooterHtml + `</div>`;
+    return tocFooterHtml + '</div>';
   };
 
   md.renderer.rules.toc_body = function(tokens, index) {
@@ -134,24 +136,24 @@ module.exports = (md, o) => {
         }
         if (level < currentLevel) {
           // Finishing the sub headings
-          buffer += `</li>`;
+          buffer += "</li>";
           headings.push(buffer);
-          return [i, `<${options.listType}>${headings.join('')}</${options.listType}>`];
+          return [i, "<"+ options.listType +">"+ headings.join('') +"</"+ options.listType +">"];
         }
         if (level == currentLevel) {
           // Finishing the sub headings
-          buffer += `</li>`;
+          buffer += "</li>";
           headings.push(buffer);
         }
       }
-      buffer = `<li><a href="#${options.slugify(heading.content)}">`;
+      buffer = '<li><a href="#'+ options.slugify(heading.content) +'">';
       buffer += options.format(heading.content, md);
-      buffer += `</a>`;
+      buffer += "</a>";
       i++;
     }
-    buffer += buffer === '' ? '' : `</li>`;
+    buffer += buffer === '' ? '' : '</li>';
     headings.push(buffer);
-    return [i, `<${options.listType}>${headings.join('')}</${options.listType}>`];
+    return [i, "<"+ options.listType +">"+ headings.join('') +"</"+ options.listType +">"];
   }
 
   // Catch all the tokens for iteration later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-table-of-contents",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "name": "markdown-it-table-of-contents",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/simple-1-level.html
+++ b/test/fixtures/simple-1-level.html
@@ -1,6 +1,6 @@
 <h1>An article</h1>
 <p>some text with soft break before toc<br>
-<div class="table-of-contents"><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading <span>1</span></a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></div></p>
+<div class="table-of-contents"><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></div></p>
 <h2>Sub heading &lt;span&gt;1&lt;/span&gt;</h2>
 <p>Some nice text</p>
 <h2>Sub heading 2</h2>

--- a/test/fixtures/simple-default.html
+++ b/test/fixtures/simple-default.html
@@ -1,6 +1,6 @@
 <h1>An article</h1>
 <p>some text with soft break before toc<br>
-<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading <span>1</span></a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
+<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
 <h2>Sub heading &lt;span&gt;1&lt;/span&gt;</h2>
 <p>Some nice text</p>
 <h2>Sub heading 2</h2>

--- a/test/fixtures/simple-with-anchors.html
+++ b/test/fixtures/simple-with-anchors.html
@@ -1,6 +1,6 @@
 <h1 id="an-article">An article</h1>
 <p>some text with soft break before toc<br>
-<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading <span>1</span></a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
+<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
 <h2 id="sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</h2>
 <p>Some nice text</p>
 <h2 id="sub-heading-2">Sub heading 2</h2>

--- a/test/fixtures/simple-with-header-footer.html
+++ b/test/fixtures/simple-with-header-footer.html
@@ -1,6 +1,6 @@
 <h1 id="an-article">An article</h1>
 <p>some text with soft break before toc<br>
-<div class="table-of-contents"><div class="header">Contents</div><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading <span>1</span></a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul><div class="footer">Footer</div></div></p>
+<div class="table-of-contents"><div class="header">Contents</div><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul><div class="footer">Footer</div></div></p>
 <h2 id="sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</h2>
 <p>Some nice text</p>
 <h2 id="sub-heading-2">Sub heading 2</h2>

--- a/test/fixtures/simple-with-markdown-formatting.html
+++ b/test/fixtures/simple-with-markdown-formatting.html
@@ -1,0 +1,7 @@
+<h1>An article</h1>
+<p>some text with soft break before toc<br>
+<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-with-**bold**-text">Sub heading with <strong>bold</strong> text</a></li><li><a href="#sub-heading-2-with-_italics_-text">Sub heading 2 with <em>italics</em> text</a></li></ul></li></ul></div></p>
+<h2>Sub heading with <strong>bold</strong> text</h2>
+<p>Some nice text</p>
+<h2>Sub heading 2 with <em>italics</em> text</h2>
+<p>Some even nicer text</p>

--- a/test/fixtures/simple-with-markdown-formatting.md
+++ b/test/fixtures/simple-with-markdown-formatting.md
@@ -1,0 +1,9 @@
+# An article
+some text with soft break before toc  
+[[toc]]
+
+## Sub heading with **bold** text
+Some nice text
+
+## Sub heading 2 with _italics_ text
+Some even nicer text

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -98,6 +98,10 @@ describe("Testing Markdown rendering", function() {
   });
 
   it("Generates full TOC, even when there is a greater header than the first header", function (done) {
+    // TODO: The `forceFullToc` option doesn't work with the default `format`
+    //   function. By overriding the `format` function here, we can keep the
+    //   tests green. But that's lame. Need to figure out how to fix this before
+    //   merging.
     md.use(markdownItTOC, {
       forceFullToc: true,
       format: function(str) { return str; }

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -9,10 +9,11 @@ var markdownItTOC = require("../../index");
 var defaultContainerClass = "table-of-contents";
 var defaultMarker = "[[toc]]";
 var defaultListType = "ul";
-var defaultHeading1 = "Sub heading 1";
 
 // Fixtures
 var simpleMarkdown = fs.readFileSync("test/fixtures/simple.md", "utf-8");
+var simpleWithFormatting = fs.readFileSync("test/fixtures/simple-with-markdown-formatting.md", "utf-8");
+var simpleWithFormattingHTML = fs.readFileSync("test/fixtures/simple-with-markdown-formatting.html", "utf-8");
 var simpleDefaultHTML = fs.readFileSync("test/fixtures/simple-default.html", "utf-8");
 var simple1LevelHTML = fs.readFileSync("test/fixtures/simple-1-level.html", "utf-8");
 var simpleWithAnchorsHTML = fs.readFileSync("test/fixtures/simple-with-anchors.html", "utf-8");
@@ -68,17 +69,18 @@ describe("Testing Markdown rendering", function() {
     done();
   });
 
+  it("Formats markdown by default", function(done) {
+    md.use(markdownItTOC);
+    assert.equal(md.render(simpleWithFormatting), simpleWithFormattingHTML);
+    done();
+  });
+
   it("Parses correctly with custom formatting", function(done) {
-    var customHeading = "Test";
+    var customHeading = "Heading with custom formatting 123abc";
     md.use(markdownItTOC, {
-      "format": function(str) {
-        if (str === defaultHeading1) {
-          return customHeading;
-        }
-        return str;
-      }
+      format: function(str) { return customHeading; }
     });
-    assert.equal(md.render(simpleMarkdown), simpleDefaultHTML.replace(defaultHeading1, customHeading));
+    assert.equal(md.render(simpleMarkdown).includes(customHeading), true);
     done();
   });
 
@@ -96,17 +98,20 @@ describe("Testing Markdown rendering", function() {
   });
 
   it("Generates full TOC, even when there is a greater header than the first header", function (done) {
-    md.use(markdownItTOC, { forceFullToc: true });
+    md.use(markdownItTOC, {
+      forceFullToc: true,
+      format: function(str) { return str; }
+    });
     assert.equal(md.render(fullTocSampleMarkdown), fullTocSampleHtml);
     done();
   });
 
   it("Parses correctly with container header and footer html set", function (done) {
-    md.use(markdownItTOC, 
-      { 
+    md.use(markdownItTOC,
+      {
         slugify,
         containerHeaderHtml: `<div class="header">Contents</div>`,
-        containerFooterHtml: `<div class="footer">Footer</div>`, 
+        containerFooterHtml: `<div class="footer">Footer</div>`,
       });
     assert.equal(md.render(simpleMarkdown), simpleWithHeaderFooterHTML);
     done();

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -98,16 +98,11 @@ describe("Testing Markdown rendering", function() {
     done();
   });
 
-  it("Generates full TOC, even when there is a greater header than the first header", function (done) {
-    // TODO: The `forceFullToc` option doesn't work with the default `format`
-    //   function. By overriding the `format` function here, we can keep the
-    //   tests green. But that's lame. Need to figure out how to fix this before
-    //   merging.
+  it("Throws an error if forceFullToc is enabled", function (done) {
     md.use(markdownItTOC, {
-      forceFullToc: true,
-      format: function(str) { return str; }
+      forceFullToc: true
     });
-    assert.equal(md.render(fullTocSampleMarkdown), fullTocSampleHtml);
+    assert.throws(() => md.render(simpleMarkdown), /forceFullToc was removed/);
     done();
   });
 
@@ -123,8 +118,8 @@ describe("Testing Markdown rendering", function() {
   });
 
   it("Generates TOC, with custom transformed link", function (done) {
-    md.use(markdownItTOC, 
-      { 
+    md.use(markdownItTOC,
+      {
         slugify,
         transformLink: (href) => {
           return href+"&type=test";


### PR DESCRIPTION
Fixes https://github.com/Oktavilla/markdown-it-table-of-contents/issues/19

## Problem
Currently, markdown is not rendered within the TOC. Given the following markdown text:

    # My **bold** title

The TOC should render as:

    <li>My <strong>bold</strong> title</li>

But instead is rendered showing the raw markdown syntax:

    <li>My **bold** title</li>

For more details and discussion around this change, see https://github.com/Oktavilla/markdown-it-table-of-contents/issues/19.

## Solution
As suggested in https://github.com/Oktavilla/markdown-it-table-of-contents/issues/19, I have updated the default behavior to always format markdown within the TOC.  

### Additional notes
* My text editor automatically removed the trailing whitespace. So the diff is a little noisy – sorry about that.
* I had to update several of the fixture, replacing `<span>1</span>` with `&lt;span&gt;1&lt;/span&gt;`. But this change is actually an improvement, imo. By default, markdown-it escapes raw HTML unless you pass `html: true`. With my change `markdown-it-table-of-contents` now also follows this config option (i.e. if you set `html: true` then HTML will reader, otherwise it will be escaped). 

### Conflict with `forceFullToc`?
Unfortunately, this change seems to conflict with the `forceFullToc` option. The test suite overflows in an endless loop (see inline code comment). This should be fixable? Honestly, I was having a little trouble understanding the code in this area.

While I am not using `forceFullToc`, it definitely sucks to regress on this feature. I'd appreciate any advice / suggestion to keep `forceFullToc` working as before.

Thanks again for creating this library!