### PR TITLE
 Adding support to transform TOC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Name                   | Description                                            
 "forceFullToc"         | If true, renders all the headers in TOC, even if the headers are in incorrect order | false
 "containerHeaderHtml"  | Optional HTML string for container header                                           | `<div class="toc-container-header">Contents</div>`
 "containerFooterHtml"  | Optional HTML string for container footer                                           | `<div class="toc-container-footer">Footer</div>`
+"transformLink"        | A function for transforming the TOC links                                           | `undefined`
 
 `format` is an optional function for changing how the headings are displayed in the TOC.
 ```js

--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ function format(headingAsString) {
   return manipulatedHeadingString;
 }
 ```
+
+`transformLink` is an optional function for transform the link as you like.
+```js
+function transformLink(link) {
+  // transform the link as you like here.
+  return transformedLink;
+}
+```

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const defaults = {
   forceFullToc: false,
   containerHeaderHtml: undefined,
   containerFooterHtml: undefined,
+  transformLink: undefined,
 };
 
 module.exports = (md, o) => {
@@ -142,7 +143,12 @@ module.exports = (md, o) => {
           headings.push(buffer);
         }
       }
-      buffer = `<li><a href="#${options.slugify(heading.content)}">`;
+      var slugifiedContent = options.slugify(heading.content);
+      var link = "#"+slugifiedContent;
+      if (options.transformLink) {
+          link = options.transformLink(link);
+      }
+      buffer = "<li><a href=\"" + link + "\">";
       buffer += typeof options.format === 'function' ? options.format(heading.content) : heading.content;
       buffer += `</a>`;
       i++;

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = (md, o) => {
       if (options.transformLink) {
           link = options.transformLink(link);
       }
-      buffer = "<li><a href=\"" + link + "\">";
+      buffer = `<li><a href="${link}">`;
       buffer += typeof options.format === 'function' ? options.format(heading.content) : heading.content;
       buffer += `</a>`;
       i++;

--- a/test/fixtures/simple-with-transform-link.html
+++ b/test/fixtures/simple-with-transform-link.html
@@ -1,0 +1,7 @@
+<h1 id="an-article">An article</h1>
+<p>some text with soft break before toc<br>
+<div class="table-of-contents"><ul><li><a href="#an-article&type=test">An article</a><ul><li><a href="#sub-heading-%3Cspan%3E1%3C%2Fspan%3E&type=test">Sub heading <span>1</span></a></li><li><a href="#sub-heading-2&type=test">Sub heading 2</a></li></ul></li></ul></div></p>
+<h2 id="sub-heading-%3Cspan%3E1%3C%2Fspan%3E">Sub heading &lt;span&gt;1&lt;/span&gt;</h2>
+<p>Some nice text</p>
+<h2 id="sub-heading-2">Sub heading 2</h2>
+<p>Some even nicer text</p>

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -17,6 +17,7 @@ var simpleDefaultHTML = fs.readFileSync("test/fixtures/simple-default.html", "ut
 var simple1LevelHTML = fs.readFileSync("test/fixtures/simple-1-level.html", "utf-8");
 var simpleWithAnchorsHTML = fs.readFileSync("test/fixtures/simple-with-anchors.html", "utf-8");
 var simpleWithHeaderFooterHTML = fs.readFileSync("test/fixtures/simple-with-header-footer.html", "utf-8");
+var simpleWithTransformLink = fs.readFileSync("test/fixtures/simple-with-transform-link.html", "utf-8");
 var emptyMarkdown = defaultMarker;
 var emptyMarkdownHtml = fs.readFileSync("test/fixtures/empty.html", "utf-8");
 var fullTocSampleMarkdown = fs.readFileSync("test/fixtures/full-toc-sample.md", "utf-8");
@@ -109,6 +110,18 @@ describe("Testing Markdown rendering", function() {
         containerFooterHtml: `<div class="footer">Footer</div>`, 
       });
     assert.equal(md.render(simpleMarkdown), simpleWithHeaderFooterHTML);
+    done();
+  });
+
+  it("Generates TOC, with custom transformed link", function (done) {
+    md.use(markdownItTOC, 
+      { 
+        slugify,
+        transformLink: (href) => {
+          return href+"&type=test";
+        },
+      });
+    assert.equal(md.render(simpleMarkdown), simpleWithTransformLink);
     done();
   });
 });


### PR DESCRIPTION
Adding functionality in toc to apply a transformation to the link
 
By default link is as  #{header}. Using this function consumer can override this functionality and choose what they want as a link.