### PR TITLE
Ignore formatting for slugs and list item text

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,13 +122,16 @@ module.exports = function(md, o) {
           headings.push(buffer);
         }
       }
-      var slugifiedContent = options.slugify(heading.content);
+      var content = heading.children
+        .filter((token) => token.type === 'text' || token.type === 'code_inline')
+        .reduce((acc, t) => acc + t.content, '');
+      var slugifiedContent = options.slugify(content);
       var link = "#"+slugifiedContent;
       if (options.transformLink) {
           link = options.transformLink(link);
       }
       buffer = `<li><a href="${link}">`;
-      buffer += options.format(heading.content, md, link);
+      buffer += options.format(content, md, link);
       buffer += `</a>`;
       i++;
     }

--- a/test/fixtures/simple-with-heading-links.html
+++ b/test/fixtures/simple-with-heading-links.html
@@ -1,0 +1,6 @@
+<h1 id="an-article">An article</h1>
+<p><div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-1">Sub heading 1</a></li><li><a href="#sub-heading-2">Sub heading 2</a></li></ul></li></ul></div></p>
+<h2 id="sub-heading-1"><a href="http://www.test.com">Sub heading 1</a></h2>
+<p>Some nice text</p>
+<h2 id="sub-heading-2">Sub <a href="http://www.test.com">heading</a> 2</h2>
+<p>Some even nicer text</p>

--- a/test/fixtures/simple-with-heading-links.md
+++ b/test/fixtures/simple-with-heading-links.md
@@ -1,0 +1,9 @@
+# An article
+
+[[toc]]
+
+## [Sub heading 1](http://www.test.com)
+Some nice text
+
+## Sub [heading](http://www.test.com) 2
+Some even nicer text

--- a/test/fixtures/simple-with-markdown-formatting.html
+++ b/test/fixtures/simple-with-markdown-formatting.html
@@ -1,6 +1,6 @@
 <h1>An article</h1>
 <p>some text with soft break before toc<br>
-<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-with-**bold**-text">Sub heading with <strong>bold</strong> text</a></li><li><a href="#sub-heading-2-with-_italics_-text">Sub heading 2 with <em>italics</em> text</a></li></ul></li></ul></div></p>
+<div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading-with-bold-text">Sub heading with bold text</a></li><li><a href="#sub-heading-2-with-italics-text">Sub heading 2 with italics text</a></li></ul></li></ul></div></p>
 <h2>Sub heading with <strong>bold</strong> text</h2>
 <p>Some nice text</p>
 <h2>Sub heading 2 with <em>italics</em> text</h2>

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -19,6 +19,8 @@ var simple1LevelHTML = fs.readFileSync("test/fixtures/simple-1-level.html", "utf
 var simpleWithAnchorsHTML = fs.readFileSync("test/fixtures/simple-with-anchors.html", "utf-8");
 var simpleWithHeaderFooterHTML = fs.readFileSync("test/fixtures/simple-with-header-footer.html", "utf-8");
 var simpleWithTransformLink = fs.readFileSync("test/fixtures/simple-with-transform-link.html", "utf-8");
+var simpleWithHeadingLink = fs.readFileSync("test/fixtures/simple-with-heading-link.md", "utf-8");
+var simpleWithHeadingLinkHTML = fs.readFileSync("test/fixtures/simple-with-heading-link.html", "utf-8");
 var emptyMarkdown = defaultMarker;
 var emptyMarkdownHtml = fs.readFileSync("test/fixtures/empty.html", "utf-8");
 var fullTocSampleMarkdown = fs.readFileSync("test/fixtures/full-toc-sample.md", "utf-8");
@@ -148,6 +150,12 @@ describe("Testing Markdown rendering", function() {
         },
       });
     assert.equal(adjustEOL(md.render(simpleMarkdown)), simpleWithTransformLink);
+    done();
+  });
+
+  it("Parses correctly when headers are links", function (done) {
+    md.use(markdownItTOC);
+    assert.equal(adjustEOL(md.render(simpleWithHeadingLink)), simpleWithHeadingLinkHTML);
     done();
   });
 });


### PR DESCRIPTION
This is the change from https://github.com/martinlissmyr/markdown-it-table-of-contents/pull/46 but with test cases.

Fixes https://github.com/martinlissmyr/markdown-it-table-of-contents/issues/37