### PR TITLE
Fixed header links to increment if duplicates found

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,12 @@ module.exports = function(md, o) {
   var options = Object.assign({}, defaults, o);
   var tocRegexp = options.markerPattern;
   var gstate;
+  var links;
 
   function toc(state, silent) {
     var token;
     var match;
+    links = [];
 
     // Reject if the token does not start with [
     if (state.src.charCodeAt(state.pos) !== 0x5B /* [ */ ) {
@@ -127,8 +129,17 @@ module.exports = function(md, o) {
       if (options.transformLink) {
           link = options.transformLink(link);
       }
-      buffer = `<li><a href="${link}">`;
-      buffer += options.format(heading.content, md, link);
+
+      // Check if this link has been generated before and increment link if so
+      var generatedLink = link;
+      var index = 2;
+      while (links.indexOf(generatedLink) >= 0) {
+        generatedLink = link + "-" + index++;
+      }
+      links.push(generatedLink);
+
+      buffer = `<li><a href="${generatedLink}">`;
+      buffer += options.format(heading.content, md, generatedLink);
       buffer += `</a>`;
       i++;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-table-of-contents",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/fixtures/simple-with-duplicate-headings.html
+++ b/test/fixtures/simple-with-duplicate-headings.html
@@ -1,0 +1,16 @@
+<h1 id="an-article">An article</h1>
+<p><div class="table-of-contents"><ul><li><a href="#an-article">An article</a><ul><li><a href="#sub-heading">Sub heading</a><ul><li><a href="#common-sub-heading">Common sub heading</a><ul><li><a href="#duplicate-heading">Duplicate heading</a></li><li><a href="#duplicate-heading-2">Duplicate heading</a></li></ul></li></ul></li><li><a href="#sub-heading-2">Sub heading 2</a><ul><li><a href="#common-sub-heading-2">Common sub heading</a></li></ul></li><li><a href="#duplicate-heading-3">Duplicate heading</a></li></ul></li></ul></div></p>
+<h2 id="sub-heading">Sub heading</h2>
+<p>Some nice text</p>
+<h3 id="common-sub-heading">Common sub heading</h3>
+<p>Some very nice text</p>
+<h4 id="duplicate-heading">Duplicate heading</h4>
+<p>Some exceptionally nice text</p>
+<h4 id="duplicate-heading-2">Duplicate heading</h4>
+<p>Some exceptionally nice text</p>
+<h2 id="sub-heading-2">Sub heading 2</h2>
+<p>Some even nicer text</p>
+<h3 id="common-sub-heading-2">Common sub heading</h3>
+<p>Some more nice text</p>
+<h2 id="duplicate-heading-3">Duplicate heading</h2>
+<p>Some exceptionally nice text</p>

--- a/test/fixtures/simple-with-duplicate-headings.md
+++ b/test/fixtures/simple-with-duplicate-headings.md
@@ -1,0 +1,24 @@
+# An article
+
+[[toc]]
+
+## Sub heading
+Some nice text
+
+### Common sub heading
+Some very nice text
+
+#### Duplicate heading
+Some exceptionally nice text
+
+#### Duplicate heading
+Some exceptionally nice text
+
+## Sub heading 2
+Some even nicer text
+
+### Common sub heading
+Some more nice text
+
+## Duplicate heading
+Some exceptionally nice text

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -19,8 +19,10 @@ var simple1LevelHTML = fs.readFileSync("test/fixtures/simple-1-level.html", "utf
 var simpleWithAnchorsHTML = fs.readFileSync("test/fixtures/simple-with-anchors.html", "utf-8");
 var simpleWithHeaderFooterHTML = fs.readFileSync("test/fixtures/simple-with-header-footer.html", "utf-8");
 var simpleWithTransformLink = fs.readFileSync("test/fixtures/simple-with-transform-link.html", "utf-8");
-var simpleWithHeadingLink = fs.readFileSync("test/fixtures/simple-with-heading-link.md", "utf-8");
-var simpleWithHeadingLinkHTML = fs.readFileSync("test/fixtures/simple-with-heading-link.html", "utf-8");
+var simpleWithHeadingLink = fs.readFileSync("test/fixtures/simple-with-heading-links.md", "utf-8");
+var simpleWithHeadingLinkHTML = fs.readFileSync("test/fixtures/simple-with-heading-links.html", "utf-8");
+var simpleWithDuplicateHeadings = fs.readFileSync("test/fixtures/simple-with-duplicate-headings.md", "utf-8");
+var simpleWithDuplicateHeadingsHTML = fs.readFileSync("test/fixtures/simple-with-duplicate-headings.html", "utf-8");
 var emptyMarkdown = defaultMarker;
 var emptyMarkdownHtml = fs.readFileSync("test/fixtures/empty.html", "utf-8");
 var fullTocSampleMarkdown = fs.readFileSync("test/fixtures/full-toc-sample.md", "utf-8");
@@ -156,6 +158,14 @@ describe("Testing Markdown rendering", function() {
   it("Parses correctly when headers are links", function (done) {
     md.use(markdownItTOC);
     assert.equal(adjustEOL(md.render(simpleWithHeadingLink)), simpleWithHeadingLinkHTML);
+    done();
+  });
+
+  it("Parses correctly with duplicate headers", function (done) {
+    md.use(markdownItTOC, {
+      "includeLevel": [1,2,3,4]
+    });
+    assert.equal(adjustEOL(md.render(simpleWithDuplicateHeadings)), simpleWithDuplicateHeadingsHTML);
     done();
   });
 });


### PR DESCRIPTION
I ran across the issue of headers generating the same links if they have the same name.

Based on the way markdown generates heard links (based on [this](https://docs.gitlab.com/ee/user/markdown.html#header-ids-and-links) documentation I found):

> The IDs are generated from the content of the header according to the following rules:
>
> 1. All text is converted to lowercase.
> 2. All non-word text (e.g., punctuation, HTML) is removed.
> 3. All spaces are converted to hyphens.
> 4. Two or more hyphens in a row are converted to one.
> 5. If a header with the same ID has already been generated, a unique incrementing number is appended, starting at 1.

Seems to be accurate. Judging by the default `slugify`, it seems like only rules 1 and 3 are being used, but I haven't tested this.

I added logic to cover rule 5, although it appears to be the case that the number appended actually starts at 2.

I might additional test cases for duplicate header names if I have time tomorrow.