### PR TITLE
TOC links broken when there are special characters in headings fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
 */
 
 const slugify = function (s) {
-    return encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'));
+    return encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-').replace(/[.\/$+()\[\]#@&%=]/g, ''));
 };
 
 const transformContainerOpen = function (containerClass, containerHeaderHtml) {


### PR DESCRIPTION
When there are special characters in headings (. / $ + ( ) [ ] # @ & % =) the anchor in toc links are different from the headings ids, where they are deleted.

As a result, links to headings such as "1. Introduction" or "3.2. Male / Female connectors" don't work.

This fix removes these characters from the TOC link anchor.