### PR TITLE
Fix markerPattern to support patterns not starting with bracket

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,12 +280,7 @@ const markdownItTableOfContents = function (/** @type {any} */ md, /** @type {an
 		const start = state.bMarks[startLine] + state.tShift[startLine];
 		const max = state.eMarks[startLine];
 
-		// Reject if the token does not start with [
-		if (state.src.charCodeAt(start) !== 0x5B /* [ */) {
-			return false;
-		}
-
-		// Detect [[toc]] markup
+		// Detect markup
 		match = tocRegexp.exec(state.src.substring(start, max));
 		match = !match ? [] : match.filter(function (/** @type {any} */ m) { return m; });
 		if (match.length < 1) {
@@ -300,7 +295,7 @@ const markdownItTableOfContents = function (/** @type {any} */ md, /** @type {an
 
 		// Build content
 		token = state.push('toc_open', 'toc', 1);
-		token.markup = '[[toc]]';
+		token.markup = match[0];
 		token.map = [startLine, state.line];
 
 		token = state.push('toc_body', '', 0);

--- a/index.mjs
+++ b/index.mjs
@@ -288,12 +288,7 @@ const markdownItTableOfContents = function (/** @type {any} */ md, /** @type {an
 		const start = state.bMarks[startLine] + state.tShift[startLine];
 		const max = state.eMarks[startLine];
 
-		// Reject if the token does not start with [
-		if (state.src.charCodeAt(start) !== 0x5B /* [ */) {
-			return false;
-		}
-
-		// Detect [[toc]] markup
+		// Detect markup
 		match = tocRegexp.exec(state.src.substring(start, max));
 		match = !match ? [] : match.filter(function (/** @type {any} */ m) { return m; });
 		if (match.length < 1) {
@@ -308,7 +303,7 @@ const markdownItTableOfContents = function (/** @type {any} */ md, /** @type {an
 
 		// Build content
 		token = state.push('toc_open', 'toc', 1);
-		token.markup = '[[toc]]';
+		token.markup = match[0];
 		token.map = [startLine, state.line];
 
 		token = state.push('toc_body', '', 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "markdown-it-table-of-contents",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markdown-it-table-of-contents",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
-				"markdown-it": "~14.1.0",
+				"markdown-it": "14.1.0",
 				"markdown-it-anchor": "9.2.0",
-				"markdown-it-attrs": "^4.3.1"
+				"markdown-it-attrs": "4.3.1"
 			}
 		},
 		"node_modules/@types/linkify-it": {

--- a/test/modules/test.js
+++ b/test/modules/test.js
@@ -105,6 +105,15 @@ describe('Testing Markdown rendering', () => {
 		assert.equal(adjustEOL(md.render(simpleMarkdown.replace(defaultMarker, customMarker))), simpleDefaultHTML);
 	});
 
+	test('Custom markerPattern without bracket prefix', () => {
+		const md = new markdownIt();
+		const customMarker = '{{toc}}';
+		md.use(markdownItTOC, {
+			'markerPattern': /^\{\{toc\}\}/im
+		});
+		assert.equal(adjustEOL(md.render(simpleMarkdown.replace(defaultMarker, customMarker))), simpleDefaultHTML);
+	});
+
 	test('Parses correctly with listType set', () => {
 		const md = new markdownIt();
 		const customListType = 'ol';


### PR DESCRIPTION
Remove hardcoded bracket character check that prevented custom `markerPattern` from matching non-bracket markers like `{{toc}}`. Also use matched string for token.markup instead of hardcoded [[toc]].

**before**

```
$ time npm test
________________________________________________________
Executed in  318.14 millis    fish           external
   usr time  222.73 millis    0.33 millis  222.40 millis
   sys time   55.83 millis    1.37 millis   54.46 millis
```

**after**

```
$ time npm test
________________________________________________________
Executed in  314.79 millis    fish           external
   usr time  222.28 millis    0.24 millis  222.04 millis
   sys time   58.66 millis    1.01 millis   57.65 millis
```

Test duration remains unchanged after removing the early return.